### PR TITLE
Add Carbon and Oxide framework selection for Rust yolk

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ is tagged correctly.
 * [`games`](https://github.com/pterodactyl/yolks/tree/master/games)
   * [`rust`](https://github.com/pterodactyl/yolks/tree/master/games/rust)
     * `ghcr.io/pterodactyl/games:rust`
+    * Supports installing [Carbon](https://github.com/Carbon-Mod/Carbon) or [uMod (Oxide)](https://umod.org/) by setting the `FRAMEWORK` variable to `carbon` or `oxide`.
   * [`source`](https://github.com/pterodactyl/yolks/tree/master/games/source)
     * `ghcr.io/pterodactyl/games:source`
 * [`golang`](https://github.com/pterodactyl/yolks/tree/master/go)

--- a/games/rust/entrypoint.sh
+++ b/games/rust/entrypoint.sh
@@ -4,9 +4,38 @@ cd /home/container
 # Make internal Docker IP address available to processes.
 export INTERNAL_IP=`ip route get 1 | awk '{print $(NF-2);exit}'`
 
-# Auto update Rust if enabled
+FRAMEWORK_TYPE="vanilla"
+if [[ "${FRAMEWORK}" == "carbon" ]]; then
+    FRAMEWORK_TYPE="carbon"
+elif [[ "${OXIDE}" == "1" ]] || [[ "${FRAMEWORK}" == "oxide" ]]; then
+    FRAMEWORK_TYPE="oxide"
+fi
+
+# Auto update Rust and selected framework if enabled
 if [ -z ${AUTO_UPDATE} ] || [ "${AUTO_UPDATE}" == "1" ]; then
-	./steamcmd/steamcmd.sh +force_install_dir /home/container +login anonymous +app_update 258550 +quit
+        ./steamcmd/steamcmd.sh +force_install_dir /home/container +login anonymous +app_update 258550 +quit
+
+    if [[ "${FRAMEWORK_TYPE}" == "carbon" ]]; then
+        echo "Updating Carbon..."
+
+        if [[ "${RUST_STAGING}" == "1" ]]; then
+            echo "Fetching Carbon (staging build)..."
+            curl -sSL "https://api.carbonmod.org/download/staging" -o carbon.zip
+        else
+            echo "Fetching Carbon (stable build)..."
+            curl -sSL "https://api.carbonmod.org/download/latest" -o carbon.zip
+        fi
+
+        unzip -o -q carbon.zip
+        rm carbon.zip
+        echo "Done updating Carbon!"
+    elif [[ "${FRAMEWORK_TYPE}" == "oxide" ]]; then
+        echo "Updating uMod..."
+        curl -sSL "https://github.com/OxideMod/Oxide.Rust/releases/latest/download/Oxide.Rust-linux.zip" > umod.zip
+        unzip -o -q umod.zip
+        rm umod.zip
+        echo "Done updating uMod!"
+    fi
 else
     echo -e "Not updating game server as auto update was set to 0. Starting Server"
 fi
@@ -15,34 +44,11 @@ fi
 MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
 echo ":/home/container$ ${MODIFIED_STARTUP}"
 
-# --- Carbon Installation ---
-if [[ "${FRAMEWORK}" == "carbon" ]]; then
-    echo "Updating Carbon..."
-
-    if [[ "${RUST_STAGING}" == "1" ]]; then
-        echo "Fetching Carbon (staging build)..."
-        curl -sSL "https://api.carbonmod.org/download/staging" -o carbon.zip
-    else
-        echo "Fetching Carbon (stable build)..."
-        curl -sSL "https://api.carbonmod.org/download/latest" -o carbon.zip
-    fi
-
-    unzip -o -q carbon.zip
-    rm carbon.zip
-    echo "Done updating Carbon!"
-
+# Framework runtime configuration
+if [[ "${FRAMEWORK_TYPE}" == "carbon" ]]; then
     export DOORSTOP_ENABLED=1
     export DOORSTOP_TARGET_ASSEMBLY="$(pwd)/carbon/managed/Carbon.Preloader.dll"
     MODIFIED_STARTUP="LD_PRELOAD=$(pwd)/libdoorstop.so ${MODIFIED_STARTUP}"
-
-# --- Oxide Installation ---
-elif [[ "$OXIDE" == "1" ]] || [[ "${FRAMEWORK}" == "oxide" ]]; then
-    echo "Updating uMod..."
-    curl -sSL "https://github.com/OxideMod/Oxide.Rust/releases/latest/download/Oxide.Rust-linux.zip" > umod.zip
-    unzip -o -q umod.zip
-    rm umod.zip
-    echo "Done updating uMod!"
-# Else: Vanilla = Do nothing
 fi
 
 # Fix for Rust not starting


### PR DESCRIPTION
## Summary
- allow selecting Carbon or uMod (Oxide) via `FRAMEWORK` variable
- auto-update selected framework along with Rust
- document framework selection in README

## Testing
- `bash -n games/rust/entrypoint.sh`
- `node --check games/rust/wrapper.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1ae7f4c808325b2f2b2ec8bd3a460