### PR TITLE
fix: update source deps for bookworm

### DIFF
--- a/games/source/Dockerfile
+++ b/games/source/Dockerfile
@@ -31,9 +31,9 @@ ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         dpkg --add-architecture i386 \
 				&& apt update \
-				&& apt upgrade -y \
-				&& apt install -y tar curl gcc g++ lib32gcc-s1 libgcc1 libcurl4-gnutls-dev:i386 libssl3:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat-traditional tzdata \
-				&& useradd -m -d /home/container container
+                                && apt upgrade -y \
+                                && apt install -y tar curl gcc g++ lib32gcc-s1 libgcc-s1 libcurl4-gnutls-dev:i386 libssl3:i386 libcurl4:i386 zlib1g:i386 libstdc++6:i386 libtinfo6:i386 libncurses6:i386 libfontconfig1 libfontconfig1:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian telnet net-tools netcat-traditional tzdata \
+                                && useradd -m -d /home/container container
 
 USER        container
 ENV         USER=container HOME=/home/container


### PR DESCRIPTION
## Summary
- update Source image dependencies for Debian bookworm

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b0e70d40832591815f1f719cc369