### PR TITLE
fix: update source Dockerfile and rust Node install

### DIFF
--- a/games/rust/Dockerfile
+++ b/games/rust/Dockerfile
@@ -33,7 +33,7 @@ RUN			dpkg --add-architecture i386 \
 			&& apt update \
 			&& apt upgrade -y \
 			&& apt install -y lib32gcc-s1 lib32stdc++6 unzip curl iproute2 tzdata libgdiplus libsdl2-2.0-0:i386 \
-			&& curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+                        && curl -sL https://deb.nodesource.com/setup_18.x | bash - \
 			&& apt install -y nodejs \
 			&& mkdir /node_modules \
 			&& npm install --prefix / ws \

--- a/games/source/Dockerfile
+++ b/games/source/Dockerfile
@@ -32,7 +32,7 @@ ENV         DEBIAN_FRONTEND=noninteractive
 RUN         dpkg --add-architecture i386 \
 				&& apt update \
 				&& apt upgrade -y \
-				&& apt install -y tar curl gcc g++ lib32gcc-s1 libcurl4-gnutls-dev:i386 libssl3:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat-traditional tzdata \
+                                && apt install -y tar curl gcc g++ lib32gcc-s1 libcurl4-gnutls-dev:i386 libssl3:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses6:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat-traditional tzdata \
 				&& useradd -m -d /home/container container
 
 USER        container


### PR DESCRIPTION
## Summary
- use `libncurses6` in the Source image to match current Debian packages
- switch Rust image to Node.js 18 setup script to avoid long deprecation delay

## Testing
- `npm test` *(fails: Could not read package.json)*
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b58ae3148325950672c22a8a14ca