### PR TITLE
fix: install gnupg for rust image

### DIFF
--- a/games/rust/Dockerfile
+++ b/games/rust/Dockerfile
@@ -32,7 +32,7 @@ ENV         DEBIAN_FRONTEND=noninteractive
 RUN			dpkg --add-architecture i386 \
 			&& apt update \
 			&& apt upgrade -y \
-			&& apt install -y lib32gcc-s1 lib32stdc++6 unzip curl iproute2 tzdata libgdiplus libsdl2-2.0-0:i386 \
+			&& apt install -y ca-certificates gnupg lib32gcc-s1 lib32stdc++6 unzip curl iproute2 tzdata libgdiplus libsdl2-2.0-0:i386 \
                         && curl -sL https://deb.nodesource.com/setup_18.x | bash - \
 			&& apt install -y nodejs \
 			&& mkdir /node_modules \


### PR DESCRIPTION
## Summary
- install ca-certificates and gnupg for rust image to allow NodeSource script

## Testing
- `docker version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b7e73cc0832586ea7910e9db323c