### PR TITLE
fix: resolve npm install failure in Rust image

### DIFF
--- a/games/rust/Dockerfile
+++ b/games/rust/Dockerfile
@@ -34,10 +34,11 @@ RUN			dpkg --add-architecture i386 \
 			&& apt upgrade -y \
 			&& apt install -y ca-certificates gnupg lib32gcc-s1 lib32stdc++6 unzip curl iproute2 tzdata libgdiplus libsdl2-2.0-0:i386 \
                         && curl -sL https://deb.nodesource.com/setup_18.x | bash - \
-			&& apt install -y nodejs \
-			&& mkdir /node_modules \
-			&& npm install --prefix / ws \
-			&& useradd -d /home/container -m container
+                        && apt install -y nodejs \
+                        && npm install -g ws \
+                        && mkdir /node_modules \
+                        && ln -s $(npm root -g)/ws /node_modules/ws \
+                        && useradd -d /home/container -m container
 
 USER 		container
 ENV  		USER=container HOME=/home/container


### PR DESCRIPTION
## Summary
- install `ws` globally and symlink it into `/node_modules` to avoid npm idealTree error during build

## Testing
- `docker build -t test-rust games/rust` *(fails: bash: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b8ec1b488325a3151573fc41e74c